### PR TITLE
Fixing errors with /lib/rtlcss/RTLCSS.php

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -163,13 +163,10 @@
 #page-mod-englishcentral-view .chart .outerring {
     margin-left:      50%;
     height:          100%;
-    border-radius: 0 100% 100% 0 / 50%;
-    /***********************************
-    border-top-left-radius       0% 50%;
-    border-top-right-radius      0% 50%;
-    border-bottom-right-radius 100% 50%;
-    border-bottom-left-radius  100% 50%;
-    ***********************************/
+    border-top-left-radius:       0% 50%;
+    border-top-right-radius:      0% 50%;
+    border-bottom-right-radius: 100% 50%;
+    border-bottom-left-radius:  100% 50%;
     transform-origin: left;
 }
 


### PR DESCRIPTION
Moodle's RTLCSS script fails to properly parse the following CSS:
    border-radius: 0 100% 100% 0 / 50%;

So I removed that line and uncommented out the lines that follow that should produce the same results.

To duplicate the error run the following script:

php admin/cli/build_theme_css.php

On our Moodle 3.4.4 system we got the following errors:

php admin/cli/build_theme_css.php
== Build theme css ==
Default exception handler: Exception - Call to undefined method Sabberworm\CSS\Value\Size::getListComponents() Debug: 
Error code: generalexceptionmessage
* line 273 of /lib/rtlcss/RTLCSS.php: Error thrown
* line 223 of /lib/rtlcss/RTLCSS.php: call to MoodleHQ\RTLCSS\RTLCSS->processRule()
* line 55 of /lib/classes/rtlcss.php: call to MoodleHQ\RTLCSS\RTLCSS->processDeclaration()
* line 192 of /lib/rtlcss/RTLCSS.php: call to core_rtlcss->processDeclaration()
* line 63 of /lib/rtlcss/RTLCSS.php: call to MoodleHQ\RTLCSS\RTLCSS->processBlock()
* line 1897 of /lib/outputlib.php: call to MoodleHQ\RTLCSS\RTLCSS->flip()
* line 1875 of /lib/outputlib.php: call to theme_config->rtlize()
* line 1110 of /lib/outputlib.php: call to theme_config->post_process()
* line 208 of /lib/outputlib.php: call to theme_config->get_css_content()
* line 117 of /admin/cli/build_theme_css.php: call to theme_build_css_for_themes()
