### PR TITLE
fixed broken course reset due to incorrect table name

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -378,7 +378,7 @@ function englishcentral_reset_userdata($data) {
 
         $params = array ("course" => $data->courseid);
         $DB->delete_records_select('englishcentral_attempts', "ecid IN ($englishcentralssql)", $params);
-        $DB->delete_records_select('englishcentral_phs', "ecid IN ($englishcentralssql)", $params);
+        $DB->delete_records_select('englishcentral_phonemes', "ecid IN ($englishcentralssql)", $params);
 
         // remove all grades from gradebook
         if (empty($data->reset_gradebook_grades)) {


### PR DESCRIPTION
The reset code was looking for phonemes table at mdl_englishcentral_phs which I think is a hangover from v1. I am not even sure we still use the phonemes table. I just fixed the table name so course reset doesn't break.