### PR TITLE
Adding support for @ and . in Poodll API username

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,7 @@ Change log for mod_englishcentral
 ========================================
 
 2020-03-XX unreleased
- - added support for @ mark in Poodll API user
+ - added support for @ mark and periods in Poodll API user
 
 2020-03-01 (10)
  - include current version in tool to redo upgrade

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,9 @@
 Change log for mod_englishcentral
 ========================================
 
+2020-03-XX unreleased
+ - added support for @ mark in Poodll API user
+
 2020-03-01 (10)
  - include current version in tool to redo upgrade
 

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -380,7 +380,7 @@ class auth {
     }
 
     public function missing_poodllapi_config() {
-        $missing = array('poodllapiuser' => '/^[0-9a-zA-Z\/+=]+$/',
+        $missing = array('poodllapiuser' => '/^[0-9a-zA-Z\/@+=]+$/',
                          'poodllapisecret' => '/^[0-9a-zA-Z\/+=-]+$/');
         foreach ($missing as $name => $pattern) {
             if (isset($this->ec->config->$name) && preg_match($pattern, $this->ec->config->$name)) {

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -380,7 +380,7 @@ class auth {
     }
 
     public function missing_poodllapi_config() {
-        $missing = array('poodllapiuser' => '/^[0-9a-zA-Z\/@+=]+$/',
+        $missing = array('poodllapiuser' => '/^[0-9a-zA-Z\/\.@+=]+$/',
                          'poodllapisecret' => '/^[0-9a-zA-Z\/+=-]+$/');
         foreach ($missing as $name => $pattern) {
             if (isset($this->ec->config->$name) && preg_match($pattern, $this->ec->config->$name)) {


### PR DESCRIPTION
Sometimes people use their email address as username and this was not passing the auth->missing_config() check